### PR TITLE
fix(WEB-5): dynamic copyright year in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -30,7 +30,7 @@
 				</ul>
 
 				<p class="copyright">
-					© 2025 aaas24, All Rights Reserved.
+					© {{ site.time | date: '%Y' }} aaas24, All Rights Reserved.
 				</p>
 
 			</div>


### PR DESCRIPTION
## Summary

- Replaced hardcoded `© 2025` in `_includes/footer.html` with `{{ site.time | date: '%Y' }}` so the footer always shows the current year on each build.

## Test plan

- [ ] Run `bundle exec jekyll serve` locally and confirm the footer shows `2026`.
- [ ] Inspect rendered HTML source to verify no raw Liquid tag is visible.
- [ ] Push to GitHub Pages and confirm the live footer year is correct.

Closes WEB-5

🤖 Generated with [Claude Code](https://claude.com/claude-code)