### PR TITLE
Court Call community hub at /court-call/

### DIFF
--- a/_layouts/court-call.html
+++ b/_layouts/court-call.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>{% if page.title %}{{ page.title }}{% else %}Court Call{% endif %}</title>
+<meta name="description" content="{% if page.description %}{{ page.description }}{% else %}Court Call — a player-run tennis community.{% endif %}" />
+<link rel="canonical" href="{{ page.url | prepend: site.url }}" />
+<!-- Google Tag Manager (shared site container) -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-5MM9LPM8');</script>
+<!-- End Google Tag Manager -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,500;12..96,700;12..96,800&family=Familjen+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<link href="/assets/court-call/court-call.css" rel="stylesheet" />
+</head>
+<body>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5MM9LPM8"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+<!-- NAV -->
+<nav>
+  <div class="wrap">
+    <a class="brand" href="/court-call/">
+      <svg class="mark" width="34" height="34" viewBox="0 0 120 120" aria-hidden="true">
+        <g transform="translate(60,60) scale(1.2) translate(-76.25,-60)">
+          <path class="arc" d="M46 33 A47 47 0 0 0 46 87" stroke-width="5.5"/>
+          <path class="arc" d="M55 41 A35 35 0 0 0 55 79" stroke-width="4.6" opacity="0.82"/>
+          <circle cx="90" cy="60" r="25" fill="#79873a"/>
+          <path d="M103 45 C88 54 88 66 103 75" fill="none" stroke="#0d1014" stroke-width="2.2" stroke-linecap="round" opacity="0.7"/>
+        </g>
+      </svg>
+      Court Call
+    </a>
+    <div class="nav-links">
+      <a href="/court-call/privacy/">Privacy</a>
+      <a href="/court-call/community-guidelines/">Guidelines</a>
+      <a class="btn btn-pri nav-cta" href="https://discord.gg/XT3W9hThm">
+        <svg viewBox="0 0 24 24"><path d="M20 4a18 18 0 0 0-4.4-1.4l-.3.6A16 16 0 0 1 17 4a16 16 0 0 0-10 0c.5-.3 1.1-.6 1.7-.8l-.3-.6A18 18 0 0 0 4 4 19 19 0 0 0 1 18a18 18 0 0 0 5.4 2.7l.6-1a12 12 0 0 1-1.9-.9l.4-.3a13 13 0 0 0 11 0l.4.3a12 12 0 0 1-1.9.9l.6 1A18 18 0 0 0 23 18 19 19 0 0 0 20 4ZM9 15a1.7 1.7 0 0 1 0-3.4A1.7 1.7 0 0 1 9 15Zm6 0a1.7 1.7 0 0 1 0-3.4A1.7 1.7 0 0 1 15 15Z"/></svg>
+        Join
+      </a>
+    </div>
+  </div>
+</nav>
+
+<!-- DOC CONTENT -->
+<main class="wrap cc-doc">
+  {% if page.title %}<h1 class="cc-doc-title">{{ page.title }}</h1>{% endif %}
+  {{ content }}
+  <p class="cc-back"><a href="/court-call/">← Back to Court Call</a></p>
+</main>
+
+<footer>
+  <div class="wrap">
+    <span class="brand">
+      <svg width="22" height="22" viewBox="0 0 120 120" aria-hidden="true"><g transform="translate(60,60) scale(1.2) translate(-76.25,-60)"><path class="arc" d="M46 33 A47 47 0 0 0 46 87" stroke-width="6"/><path class="arc" d="M55 41 A35 35 0 0 0 55 79" stroke-width="5.2" opacity="0.82"/><circle cx="90" cy="60" r="25" fill="#79873a"/></g></svg>
+      Court Call
+    </span>
+    <span class="foot-links">
+      <a href="/court-call/privacy/">Privacy</a>
+      <a href="/court-call/community-guidelines/">Community Guidelines</a>
+    </span>
+    <span>Player-run · Self-hosted · © 2026</span>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/assets/court-call/court-call.css
+++ b/assets/court-call/court-call.css
@@ -1,0 +1,73 @@
+/* Court Call — shared styles for hub doc pages (Night Match). Mirrors court-call/index.html. */
+:root{
+  --bg:#0d1014; --surface:#161b22; --surface2:#1b212a; --line:#232a33;
+  --accent:#c8f751; --ball:#79873a; --coral:#ff5d3b;
+  --text:#f4f6f1; --muted:#9aa3ad;
+  --disp:"Bricolage Grotesque", system-ui, sans-serif;
+  --body:"Familjen Grotesk", system-ui, sans-serif;
+  --max:820px;
+}
+*{box-sizing:border-box; margin:0; padding:0}
+html{scroll-behavior:smooth}
+body{background:var(--bg); color:var(--text); font-family:var(--body); line-height:1.65;
+  -webkit-font-smoothing:antialiased}
+a{color:var(--accent); text-decoration:none}
+a:hover{text-decoration:underline}
+.wrap{max-width:var(--max); margin:0 auto; padding:0 24px}
+.accent{color:var(--accent)}
+.mark{display:block}
+.mark .arc{fill:none; stroke:var(--accent); stroke-linecap:round}
+
+/* ---------- nav ---------- */
+nav{position:sticky; top:0; z-index:50; backdrop-filter:blur(10px);
+  background:rgba(13,16,20,.72); border-bottom:1px solid var(--line)}
+nav .wrap{display:flex; align-items:center; justify-content:space-between; height:64px; max-width:1100px}
+.brand{display:flex; align-items:center; gap:11px; font-family:var(--disp); font-weight:800;
+  font-size:20px; letter-spacing:-.02em; color:var(--text)}
+.brand:hover{text-decoration:none}
+.nav-links{display:flex; align-items:center; gap:26px}
+.nav-links a{color:var(--muted); font-size:14px; font-weight:500; transition:color .15s}
+.nav-links a:hover{color:var(--text); text-decoration:none}
+.btn{font-family:var(--disp); font-weight:700; border-radius:11px; display:inline-flex;
+  align-items:center; gap:9px; cursor:pointer; border:none; transition:transform .15s, box-shadow .15s}
+.btn:hover{text-decoration:none}
+.btn-pri{background:var(--accent); color:var(--bg); padding:11px 20px; font-size:14px}
+.btn-pri:hover{transform:translateY(-2px); box-shadow:0 14px 30px -12px rgba(200,247,81,.6)}
+.btn-pri svg{width:17px; height:17px; fill:currentColor}
+@media(max-width:680px){ .nav-links a:not(.nav-cta){display:none} }
+
+/* ---------- doc body (rendered markdown) ---------- */
+.cc-doc{padding:clamp(40px,7vw,72px) 24px clamp(56px,9vw,96px)}
+.cc-doc-title{font-family:var(--disp); font-weight:800; letter-spacing:-.03em; line-height:1.04;
+  font-size:clamp(34px,6vw,56px); margin-bottom:28px}
+.cc-doc h1{font-family:var(--disp); font-weight:800; letter-spacing:-.025em; font-size:clamp(28px,5vw,42px); margin:40px 0 14px}
+.cc-doc h2{font-family:var(--disp); font-weight:700; letter-spacing:-.02em; font-size:clamp(22px,3.4vw,30px);
+  margin:38px 0 12px; padding-top:8px}
+.cc-doc h3{font-family:var(--disp); font-weight:700; font-size:19px; margin:26px 0 8px}
+.cc-doc h4{font-family:var(--disp); font-weight:700; font-size:16px; margin:20px 0 6px; color:#dfe4ea}
+.cc-doc p{color:#cfd5dc; margin:12px 0; font-size:16.5px}
+.cc-doc ul,.cc-doc ol{margin:12px 0 12px 1.3em; color:#cfd5dc}
+.cc-doc li{margin:6px 0; font-size:16.5px}
+.cc-doc strong{color:var(--text); font-weight:700}
+.cc-doc a{color:var(--accent); font-weight:500}
+.cc-doc hr{border:none; border-top:1px solid var(--line); margin:34px 0}
+.cc-doc blockquote{border-left:3px solid var(--accent); background:var(--surface);
+  border-radius:0 10px 10px 0; padding:14px 18px; margin:18px 0; color:#cfd5dc}
+.cc-doc blockquote p{margin:6px 0; font-size:15.5px}
+.cc-doc code{font-family:ui-monospace, SFMono-Regular, Menlo, monospace; background:var(--surface2);
+  border:1px solid var(--line); border-radius:6px; padding:1px 6px; font-size:.92em; color:#e9edf2}
+.cc-doc pre{background:var(--surface); border:1px solid var(--line); border-radius:12px;
+  padding:16px 18px; overflow-x:auto; margin:16px 0}
+.cc-doc pre code{background:none; border:none; padding:0}
+.cc-doc table{width:100%; border-collapse:collapse; margin:18px 0; font-size:15px}
+.cc-doc th,.cc-doc td{border:1px solid var(--line); padding:9px 12px; text-align:left}
+.cc-doc th{background:var(--surface); font-family:var(--disp); font-weight:700; color:var(--text)}
+.cc-doc td{color:#cfd5dc}
+.cc-back{margin-top:48px; padding-top:24px; border-top:1px solid var(--line)}
+
+/* ---------- footer ---------- */
+footer{border-top:1px solid var(--line); padding:40px 0; color:var(--muted); font-size:13.5px}
+footer .wrap{display:flex; justify-content:space-between; align-items:center; gap:18px; flex-wrap:wrap; max-width:1100px}
+footer .brand{font-size:16px; color:var(--text); font-family:var(--disp); font-weight:800}
+footer .foot-links{display:flex; gap:22px}
+footer .foot-links a{color:var(--text); font-size:13.5px}

--- a/court-call/docs/community-guidelines.md
+++ b/court-call/docs/community-guidelines.md
@@ -1,0 +1,120 @@
+---
+layout: court-call
+permalink: /court-call/community-guidelines/
+title: "Court Call — Community Guidelines"
+description: "The principles and rules that keep the Court Call tennis community welcoming, respectful, and safe."
+---
+
+Welcome to **Court Call**, a player-run tennis community for the Lakeway, TX area.
+
+This community is run **by players, for players**. It is **not** a club, and it isn't managed by or
+affiliated with any venue, facility, or company. We play in the same local courts, so our online
+community should reflect the same respect and sportsmanship we expect on court.
+
+By joining, you confirm you're **18 or older** and agree to the guidelines below.
+
+> These guidelines may be updated over time. If they change, we'll ask you to re-agree before
+> posting again — you'll keep your spot, just pause until you've read the new version.
+
+---
+
+## 🎾 Guiding Principles
+
+The spirit of the place. Everything below flows from these.
+
+1. **Respect above all.** Treat others as you would on court — with courtesy and fair play. No
+   disrespectful, offensive, or harmful language; no harassment, name-calling, or targeting people.
+   Disagreement is fine; rudeness isn't.
+
+2. **Keep it tennis.** Conversations center on tennis, fitness, training, equipment, and finding
+   games. Off-topic chat is welcome in designated channels, but this isn't a general-interest server
+   — we're here for tennis, not to spin up channels for unrelated hobbies or sports seasons.
+
+3. **Lift each other up.** Encourage, don't discourage. Share tips, celebrate progress, welcome new
+   players. Healthy competition is great — at nobody's expense.
+
+4. **What happens here carries to the courts.** We play in the same real-world spaces. Online words
+   follow you onto the court. Treat fellow members as neighbors, partners, and future teammates.
+
+---
+
+## ✅ The Rules
+
+The specifics that keep the community working and safe.
+
+### 1. Adults only (18+)
+Court Call is for players **18 and older**. We're a small, volunteer-run community and can't provide
+the safeguards a space with minors needs. Accounts identified as under 18 are removed. *(Note: we
+ask you to confirm your age — we don't formally verify it. The honor system only works if you're honest.)*
+
+### 2. Honor your commitments (no-shows)
+Finding games is the whole point of Court Call, and it only works if people show up.
+- If you commit to a game, **show up** — on time and ready to play.
+- If your plans change, **cancel as early as you can** so someone else can take your spot. Late
+  cancellations happen; silent no-shows hurt everyone.
+- **Chronic no-shows or repeated late flaking may lose access.** Reliability is a courtesy to your
+  fellow players, not optional.
+
+### 3. Respect privacy
+- Don't share another member's personal information — contact details, location, photos, or
+  schedule — without their consent.
+- What's shared in the community stays in the community. Don't screenshot or repost members'
+  messages elsewhere.
+
+### 4. No spam or solicitation
+- No spam, mass DMs, or repetitive self-promotion.
+- No selling, advertising, or recruiting for outside services (coaching-for-hire, gear sales,
+  other communities) without the operator's OK. When in doubt, ask first.
+
+### 5. Play fair online too
+- One account per person. Don't impersonate other members or Court Call itself.
+- Don't post illegal content, or anything that puts the community or its members at risk.
+
+---
+
+## 🛡️ Staying Safe (in-person play)
+
+Court Call helps players **find** each other — but we are a community, not a vetting service. **We
+do not background-check or verify members.** When you arrange to play with someone:
+
+- **Meet in public.** Play at public courts or other public venues, especially the first time.
+- **Cross-check on CourtReserve.** When you book the court through CourtReserve, the reservation
+  shows the players' full names. It's a simple way to confirm you're meeting who you expect before
+  you head out.
+- **Tell someone** where you're going and who you're meeting.
+- **Trust your judgment.** If something feels off, you don't owe anyone a game. Walk away.
+- **You're responsible for your own safety.** Court Call connects players in good faith but can't
+  guarantee anyone's conduct or identity.
+- If another member ever makes you feel unsafe, **report it** (below).
+
+---
+
+## 🚩 Reporting & Enforcement
+
+### How to report
+See something — harassment, a safety concern, a chronic no-show, spam? **DM the operator: Discord @aaas24.**
+
+Reports are handled discreetly. You won't get in trouble for raising a genuine concern.
+
+### What happens when rules are broken
+Enforcement is at the operator's discretion and generally escalates with the situation:
+
+1. **A friendly heads-up** — for minor or first-time slips.
+2. **A formal warning.**
+3. **Temporary removal / loss of access** — e.g. posting paused, or a time-out.
+4. **Permanent ban** — for serious or repeated violations.
+
+Some things skip straight to removal: harassment, threats, endangering another member, being under
+18, or anything that makes the community unsafe. The goal isn't to police — it's to keep Court Call
+a place people actually want to play in.
+
+---
+
+## 🤝 The short version
+
+Be a good court-mate. Show up when you say you will. Keep it about tennis. Look out for each other —
+online and on court. That's it. See you out there. 🎾
+
+---
+
+*Guidelines version: v1.0 · Last updated: 2026-05-31*

--- a/court-call/docs/privacy.md
+++ b/court-call/docs/privacy.md
@@ -1,0 +1,197 @@
+---
+layout: court-call
+permalink: /court-call/privacy/
+title: "Court Call — Privacy Notice"
+description: "How the Court Call tennis community handles your data: minimal, self-hosted, never sold."
+---
+
+> ⚠️ **Not legal advice.** This is a plain-language notice written to be honest and accurate about how
+> Court Call handles your data. It is **not** a lawyer-reviewed legal document; treat it as a
+> good-faith summary rather than binding legal terms.
+
+**Last updated:** 2026-05-31 · **Version:** v1.0
+
+---
+
+## The short version
+
+Court Call is a small, player-run, self-hosted tennis community on Discord. We collect as little
+as possible. We don't sell your data, we don't run ads, and we don't track you across the web.
+Our own systems store two kinds of things: (1) the **profile details you choose to share** so the
+bot can match you with players (like your availability), and (2) minimal **records that you confirmed
+you're 18+, agreed to the Guidelines, plus a short log of account events** so we can run the place
+and debug problems. You control your profile — remove a detail and it's gone from our server. Delete
+your account and your profile is erased; we keep only a minimal record that the account existed, for
+up to 24 months, then that's deleted too. Everything else is your normal Discord activity, governed
+by Discord.
+
+---
+
+## 1. Who runs Court Call
+
+Court Call is operated by an individual volunteer — not a company, club, or venue. Contact for any
+privacy question or request: **Discord @aaas24**.
+
+---
+
+## 2. The two layers: Discord vs. our systems
+
+It helps to separate two things:
+
+- **Discord** is the platform we run on. When you use Discord, your account, messages, profile,
+  and activity are handled by Discord under **their** privacy policy and terms — not ours. We don't
+  control that, and you should read Discord's policy directly: https://discord.com/privacy
+- **Court Call's own systems** (our self-hosted bot and database) store only the minimal records
+  described below. This notice covers *our* systems.
+
+---
+
+## 3. What we collect (and what we don't)
+
+### We store, in our own self-hosted database:
+
+**Profile data** — details you choose to share so the bot can help match you with players:
+- Information you add to your Court Call profile, such as your **gender**, **availability windows**,
+  and anything else shown in your profile.
+- This is **opt-in and self-managed**: you decide what to put there, and you can change or remove
+  any field at any time. We keep no history of profile changes.
+
+**Verification record** — when you pass the join gate:
+- Your Discord user ID (a numeric account identifier)
+- That you confirmed you are 18 or older (a yes/no — see below)
+- That you agreed to the Community Guidelines, and which version
+- Your current status (active / hold)
+- A timestamp
+
+**Audit log** — a minimal record of account lifecycle events for safe operation and debugging:
+- Your Discord user ID
+- The event (e.g. joined, verified, reminded, removed, rejoined, guidelines re-confirmed)
+- A short reason (e.g. "did not verify within 7 days")
+- A timestamp
+- *(The audit log records that an account existed and what happened to it — not your profile content.)*
+
+### We do NOT collect or store:
+- **Your date of birth, birth year, or age.** The 18+ gate stores only the *yes/no result* of your
+  confirmation — never your actual age or birthdate.
+- ID documents, face scans, or any third-party age-verification data. We don't use those services.
+- Your real name, address, phone number, email, or payment info. (There are no payments — Court Call is free.)
+- **Cross-site advertising / ad-tracking identifiers.** (Our website does use cookies for basic
+  analytics — see §5 — but not for advertising, and we don't track you across other sites.)
+- Any profile detail you haven't chosen to add yourself.
+
+> **Important honesty note:** confirming you're 18+ is *self-attested*. We **require** members to be
+> 18 or older and remove under-18 accounts when we become aware of them, but we do **not** verify
+> ages and don't claim to.
+
+---
+
+## 4. Why we collect it (purpose)
+
+- **Profile data:** so the bot can do its core job — help you find and match with other players
+  (e.g. surfacing people whose availability overlaps yours). You provide it because it makes the
+  matching useful; it's yours to manage.
+- **18+ confirmation:** to enforce our adults-only rule. Court Call connects people who may meet in
+  person; as a small volunteer community we can't provide the safeguards a space with minors needs.
+- **Guidelines agreement + version:** to record that you accepted the rules, and to ask you to
+  re-agree if the rules change.
+- **Audit log:** to operate the community responsibly — investigate problems, recognize accounts
+  removed for cause that try to rejoin, and debug our own bot. It records that an account existed
+  and its lifecycle — not your profile content.
+
+---
+
+## 5. The web hub (web.aaas24.io/court-call)
+
+Our landing page and these docs are static pages. The page uses **Google Analytics** (loaded through
+Google Tag Manager) to see basic, aggregate visit data — roughly how many people land on the page and
+where from — so we can tell whether our outreach is working. These are third-party services (Google)
+and set cookies in your browser. To be straight with you:
+
+- **No selling data.** We don't sell or trade anything the analytics collect.
+- **No ads.** We don't run advertising or ad-retargeting networks.
+- **Aggregate only.** We look at visit counts, not an individual profile of you.
+
+One honest distinction: the **community's own systems** — the bot and database that hold your
+Court Call profile — are self-hosted on infrastructure we control (see §8). The **website's visit
+analytics** are the one place we lean on a third party (Google), and only for aggregate page stats.
+
+The page links out to Discord; once you click through, Discord's policy applies. The page does **not**
+read a live Discord member count, so it makes no background calls to Discord on your behalf.
+
+---
+
+## 6. How long we keep it (retention)
+
+- **Profile data:** kept only while you choose to keep it. Remove a field and it's deleted from our
+  server immediately, with no copy retained. When you delete your account, **all your profile data
+  is erased** — we do not keep it.
+- **Verification record:** kept while it reflects your current standing. When you leave or are
+  removed, the active record is retired and a minimal event is written to the audit log.
+- **Audit log:** the bare fact that an account existed and its lifecycle events — kept for **24 months**
+  from each event, then **permanently and fully deleted**. We do not keep an anonymized copy, and the
+  audit log never contains your profile content.
+
+So after you delete your account: your profile is gone right away; only a minimal "this account
+existed / these events happened" record remains, and that too is fully deleted within 24 months.
+
+*(Retention principle: we keep data only as long as needed for the purpose above. The 24-month
+period is our operating default and is one of the items to confirm under legal review.)*
+
+---
+
+## 7. Who we share it with
+
+- **No one for marketing.** We never sell, rent, or trade your data, and we don't run ads.
+- **Service providers we run on:** Discord (the platform) and our own self-hosted infrastructure.
+  We don't hand your records to third-party data processors beyond what's needed to run the bot.
+- **Legal:** we would only disclose information if required by a valid legal obligation.
+
+---
+
+## 8. Where your data lives (self-hosted)
+
+Court Call's records live on infrastructure the operator controls directly — not on a third-party
+platform that monetizes activity. This is a deliberate, data-ownership-first choice.
+
+---
+
+## 9. Your choices and rights
+
+- **Control your profile directly.** You decide what profile details to share, and you can edit or
+  remove any of them at any time. Removing a detail deletes it from our server immediately.
+- **Leave anytime.** Leaving the Discord server / deleting your account erases your profile data and
+  retires your active verification record (a minimal account-existed event persists per the 24-month
+  rule above, then is fully deleted).
+- **Ask what we hold.** You can request a copy of the records our systems hold about you.
+- **Ask us to delete.** You can request deletion of your records, subject to the minimal audit
+  retention we need for safety; tell us and we'll explain what we can remove and when.
+- Depending on where you live, you may have additional rights (e.g. under GDPR or similar laws).
+  To exercise any of these, contact **Discord @aaas24**.
+
+---
+
+## 10. Children
+
+Court Call is for adults **18 and older**. It is not intended for, or directed to, anyone under 18.
+We don't knowingly keep accounts for under-18 users; if we learn an account belongs to someone under
+18, we remove it. If you believe an under-18 person is using Court Call, contact **Discord @aaas24**.
+
+---
+
+## 11. Security
+
+We take reasonable measures to protect the limited data we hold. No system is perfectly secure, and
+we can't guarantee absolute security — but by collecting so little, there is very little to expose.
+
+---
+
+## 12. Changes to this notice
+
+If we change this notice, we'll update the version and date above and announce material changes in
+the community. Continued use after a change means you accept the updated notice.
+
+---
+
+## 13. Contact
+
+Questions or requests about your data: **Discord @aaas24**.

--- a/court-call/index.html
+++ b/court-call/index.html
@@ -1,0 +1,367 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Court Call — Need one more?</title>
+<meta name="description" content="A player-run tennis community. Find players at your level, start your own games, and let the bot handle the planning. Free, private, self-hosted." />
+<link rel="canonical" href="https://web.aaas24.io/court-call/" />
+<!-- Google Tag Manager (shared site container) -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-5MM9LPM8');</script>
+<!-- End Google Tag Manager -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,500;12..96,700;12..96,800&family=Familjen+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<style>
+  :root{
+    --bg:#0d1014; --surface:#161b22; --surface2:#1b212a; --line:#232a33;
+    --accent:#c8f751; --ball:#79873a; --coral:#ff5d3b;
+    --text:#f4f6f1; --muted:#9aa3ad;
+    --disp:"Bricolage Grotesque", system-ui, sans-serif;
+    --body:"Familjen Grotesk", system-ui, sans-serif;
+    --max:1100px;
+  }
+  *{box-sizing:border-box; margin:0; padding:0}
+  html{scroll-behavior:smooth}
+  body{background:var(--bg); color:var(--text); font-family:var(--body); line-height:1.6;
+    -webkit-font-smoothing:antialiased; overflow-x:hidden}
+  a{color:inherit; text-decoration:none}
+  .wrap{max-width:var(--max); margin:0 auto; padding:0 24px}
+  .accent{color:var(--accent)}
+
+  /* mark */
+  .mark{display:block}
+  .mark .arc{fill:none; stroke:var(--accent); stroke-linecap:round}
+
+  /* ---------- nav ---------- */
+  nav{position:sticky; top:0; z-index:50; backdrop-filter:blur(10px);
+    background:rgba(13,16,20,.72); border-bottom:1px solid var(--line)}
+  nav .wrap{display:flex; align-items:center; justify-content:space-between; height:64px}
+  .brand{display:flex; align-items:center; gap:11px; font-family:var(--disp); font-weight:800;
+    font-size:20px; letter-spacing:-.02em}
+  .nav-links{display:flex; align-items:center; gap:26px}
+  .nav-links a{color:var(--muted); font-size:14px; font-weight:500; transition:color .15s}
+  .nav-links a:hover{color:var(--text)}
+  .btn{font-family:var(--disp); font-weight:700; border-radius:11px; display:inline-flex;
+    align-items:center; gap:9px; cursor:pointer; border:none; transition:transform .15s, box-shadow .15s}
+  .btn-pri{background:var(--accent); color:var(--bg); padding:11px 20px; font-size:14px}
+  .btn-pri:hover{transform:translateY(-2px); box-shadow:0 14px 30px -12px rgba(200,247,81,.6)}
+  .btn-pri svg{width:17px; height:17px; fill:currentColor}
+  .nav-links .nav-cta{display:inline-flex}
+  @media(max-width:680px){ .nav-links a:not(.nav-cta){display:none} }
+
+  /* ---------- hero ---------- */
+  header.hero{position:relative; overflow:hidden; padding:clamp(70px,13vw,140px) 0 clamp(60px,10vw,110px)}
+  .court-lines{position:absolute; inset:0; pointer-events:none; opacity:.5;
+    background-image:
+      linear-gradient(transparent calc(50% - 1px), rgba(200,247,81,.10) 50%, transparent calc(50% + 1px)),
+      repeating-linear-gradient(transparent 0 78px, rgba(255,255,255,.025) 78px 79px);
+  }
+  .ghost-ball{position:absolute; right:-12vw; top:8%; width:46vw; max-width:560px; aspect-ratio:1;
+    border-radius:50%; background:radial-gradient(circle at 35% 35%, rgba(121,135,58,.28), rgba(121,135,58,0) 62%);
+    filter:blur(2px); pointer-events:none}
+  .hero-inner{position:relative; z-index:2; max-width:760px}
+  .eyebrow{display:inline-flex; align-items:center; gap:9px; font-size:12px; font-weight:600;
+    letter-spacing:.18em; text-transform:uppercase; color:var(--accent);
+    border:1px solid var(--line); background:var(--surface); padding:7px 14px; border-radius:999px}
+  .eyebrow .dot{width:7px; height:7px; border-radius:50%; background:var(--accent); box-shadow:0 0 10px var(--accent)}
+  h1{font-family:var(--disp); font-weight:800; letter-spacing:-.035em; line-height:.92;
+    font-size:clamp(52px,12vw,128px); margin:22px 0 0}
+  h1 em{font-style:normal; color:var(--accent)}
+  .lede{font-size:clamp(17px,2.4vw,21px); color:#cfd5dc; max-width:50ch; margin:24px 0 34px}
+  .cta-row{display:flex; gap:14px; align-items:center; flex-wrap:wrap}
+  .btn-lg{padding:16px 28px; font-size:16px}
+  .btn-ghost{background:transparent; color:var(--text); border:1px solid var(--line); padding:16px 24px; font-size:16px}
+  .btn-ghost:hover{border-color:var(--accent); transform:translateY(-2px)}
+  .trust{display:flex; gap:20px; margin-top:30px; flex-wrap:wrap; color:var(--muted); font-size:13.5px}
+  .trust span{display:flex; align-items:center; gap:7px}
+  .trust svg{width:15px; height:15px; stroke:var(--accent); fill:none; stroke-width:2}
+
+  /* staggered reveal */
+  .reveal{opacity:0; transform:translateY(18px); animation:rise .7s cubic-bezier(.2,.7,.2,1) forwards}
+  @keyframes rise{to{opacity:1; transform:none}}
+  .d1{animation-delay:.05s}.d2{animation-delay:.15s}.d3{animation-delay:.25s}
+  .d4{animation-delay:.35s}.d5{animation-delay:.45s}
+
+  /* ---------- section scaffold ---------- */
+  section{padding:clamp(56px,9vw,104px) 0; position:relative}
+  .sec-tag{font-family:var(--disp); font-weight:700; font-size:13px; letter-spacing:.16em;
+    text-transform:uppercase; color:var(--accent); margin-bottom:14px}
+  .sec-title{font-family:var(--disp); font-weight:800; letter-spacing:-.025em; line-height:1.02;
+    font-size:clamp(30px,5vw,52px)}
+  .sec-sub{color:var(--muted); font-size:17px; max-width:54ch; margin-top:16px}
+  .divider{border-top:1px solid var(--line)}
+
+  /* ---------- pillars ---------- */
+  .pillars{display:grid; grid-template-columns:repeat(3,1fr); gap:18px; margin-top:48px}
+  @media(max-width:820px){.pillars{grid-template-columns:1fr}}
+  .pcard{background:var(--surface); border:1px solid var(--line); border-radius:18px; padding:30px 26px;
+    transition:transform .2s, border-color .2s}
+  .pcard:hover{transform:translateY(-4px); border-color:rgba(200,247,81,.4)}
+  .picon{width:52px; height:52px; border-radius:13px; background:var(--surface2); display:flex;
+    align-items:center; justify-content:center; margin-bottom:20px; border:1px solid var(--line)}
+  .picon svg{width:26px; height:26px; stroke:var(--accent); fill:none; stroke-width:1.7; stroke-linecap:round; stroke-linejoin:round}
+  .pcard h3{font-family:var(--disp); font-weight:700; font-size:21px; margin-bottom:9px; letter-spacing:-.01em}
+  .pcard p{color:var(--muted); font-size:15px}
+
+  /* ---------- bot in action ---------- */
+  .bot-grid{display:grid; grid-template-columns:1fr 1fr; gap:48px; align-items:center; margin-top:8px}
+  @media(max-width:860px){.bot-grid{grid-template-columns:1fr; gap:34px}}
+  .bot-points{list-style:none; margin-top:26px; display:flex; flex-direction:column; gap:18px}
+  .bot-points li{display:flex; gap:14px; align-items:flex-start}
+  .bot-points .tick{flex:none; width:24px; height:24px; border-radius:7px; background:rgba(200,247,81,.12);
+    display:flex; align-items:center; justify-content:center}
+  .bot-points .tick svg{width:14px; height:14px; stroke:var(--accent); fill:none; stroke-width:2.4; stroke-linecap:round; stroke-linejoin:round}
+  .bot-points b{font-family:var(--disp); font-weight:700; font-size:16px}
+  .bot-points span{color:var(--muted); font-size:14.5px; display:block}
+
+  .discord-mock{background:#1b1d23; border:1px solid var(--line); border-radius:18px; padding:22px 22px 18px;
+    box-shadow:0 30px 70px -34px rgba(0,0,0,.8)}
+  .dm-row{display:flex; gap:14px}
+  .dm-av{flex:none; width:44px; height:44px; border-radius:50%; background:var(--surface2);
+    display:flex; align-items:center; justify-content:center; border:1px solid var(--line)}
+  .dm-head{display:flex; align-items:center; gap:9px; margin-bottom:5px}
+  .dm-name{font-weight:700; color:#e9edf2; font-size:15px}
+  .dm-bot{font-size:9.5px; font-weight:700; letter-spacing:.06em; background:var(--accent); color:var(--bg);
+    padding:2px 6px; border-radius:5px}
+  .dm-time{font-size:11px; color:var(--muted)}
+  .dm-body{color:#dfe4ea; font-size:15px; line-height:1.5}
+  .dm-embed{margin-top:11px; border-left:3px solid var(--accent); background:#14161b; border-radius:6px;
+    padding:12px 14px}
+  .dm-embed .t{font-family:var(--disp); font-weight:700; font-size:14px; margin-bottom:3px}
+  .dm-embed .m{color:var(--muted); font-size:13px}
+  .dm-react{display:inline-flex; align-items:center; gap:7px; margin-top:13px; background:rgba(200,247,81,.12);
+    border:1px solid rgba(200,247,81,.4); border-radius:999px; padding:4px 11px; font-size:13px; font-weight:600}
+
+  /* ---------- not / what it's not ---------- */
+  .nots{display:grid; grid-template-columns:repeat(3,1fr); gap:18px; margin-top:48px}
+  @media(max-width:820px){.nots{grid-template-columns:1fr}}
+  .ncard{background:var(--surface); border:1px solid var(--line); border-radius:16px; padding:26px 24px}
+  .ncard .x{font-family:var(--disp); font-weight:800; font-size:15px; color:var(--coral); text-decoration:line-through;
+    text-decoration-thickness:2px; opacity:.85}
+  .ncard .y{font-family:var(--disp); font-weight:700; font-size:19px; margin-top:8px; letter-spacing:-.01em}
+  .ncard p{color:var(--muted); font-size:14.5px; margin-top:7px}
+
+  /* ---------- privacy strip ---------- */
+  .privacy{background:linear-gradient(180deg,var(--surface),rgba(22,27,34,.4)); border:1px solid var(--line);
+    border-radius:22px; padding:clamp(34px,5vw,56px); display:flex; gap:30px; align-items:center; flex-wrap:wrap}
+  .privacy .lock{flex:none; width:74px; height:74px; border-radius:18px; background:var(--surface2);
+    border:1px solid var(--line); display:flex; align-items:center; justify-content:center}
+  .privacy .lock svg{width:34px; height:34px; stroke:var(--accent); fill:none; stroke-width:1.7; stroke-linecap:round; stroke-linejoin:round}
+  .privacy .ptext{flex:1; min-width:260px}
+  .privacy h3{font-family:var(--disp); font-weight:800; font-size:clamp(22px,3vw,30px); letter-spacing:-.02em}
+  .privacy p{color:var(--muted); font-size:16px; margin-top:10px; max-width:60ch}
+
+  /* ---------- join ---------- */
+  .join{text-align:center; position:relative; overflow:hidden}
+  .join .court-lines{opacity:.4}
+  .join-inner{position:relative; z-index:2; max-width:680px; margin:0 auto}
+  .join h2{font-family:var(--disp); font-weight:800; font-size:clamp(38px,7vw,76px); letter-spacing:-.03em; line-height:.95}
+  .join h2 em{font-style:normal; color:var(--accent)}
+  .join p{color:#cfd5dc; font-size:18px; margin:18px auto 30px; max-width:46ch}
+  .join-card{display:inline-flex; align-items:center; gap:24px; background:var(--surface); border:1px solid var(--line);
+    border-radius:20px; padding:22px 26px; margin-top:8px; flex-wrap:wrap; justify-content:center}
+  .qr-tile{background:#fff; border-radius:12px; padding:9px; line-height:0}
+  .qr-tile canvas{display:block; width:104px; height:104px}
+  .join-card .jc-text{text-align:left}
+  .join-card .jc-text .h{font-family:var(--disp); font-weight:700; font-size:18px}
+  .join-card .jc-text .s{color:var(--muted); font-size:13.5px; margin:3px 0 12px}
+
+  /* ---------- footer ---------- */
+  footer{border-top:1px solid var(--line); padding:40px 0; color:var(--muted); font-size:13.5px}
+  footer .wrap{display:flex; justify-content:space-between; align-items:center; gap:18px; flex-wrap:wrap}
+  footer .brand{font-size:16px; color:var(--text)}
+</style>
+</head>
+<body>
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5MM9LPM8"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
+
+<!-- NAV -->
+<nav>
+  <div class="wrap">
+    <a class="brand" href="#top">
+      <svg class="mark" width="34" height="34" viewBox="0 0 120 120" aria-hidden="true">
+        <g transform="translate(60,60) scale(1.2) translate(-76.25,-60)">
+          <path class="arc" d="M46 33 A47 47 0 0 0 46 87" stroke-width="5.5"/>
+          <path class="arc" d="M55 41 A35 35 0 0 0 55 79" stroke-width="4.6" opacity="0.82"/>
+          <circle cx="90" cy="60" r="25" fill="#79873a"/>
+          <path d="M103 45 C88 54 88 66 103 75" fill="none" stroke="#0d1014" stroke-width="2.2" stroke-linecap="round" opacity="0.7"/>
+        </g>
+      </svg>
+      Court Call
+    </a>
+    <div class="nav-links">
+      <a href="#how">How it works</a>
+      <a href="#not">What it is</a>
+      <a href="#privacy">Privacy</a>
+      <a class="btn btn-pri nav-cta" href="https://discord.gg/XT3W9hThm">
+        <svg viewBox="0 0 24 24"><path d="M20 4a18 18 0 0 0-4.4-1.4l-.3.6A16 16 0 0 1 17 4a16 16 0 0 0-10 0c.5-.3 1.1-.6 1.7-.8l-.3-.6A18 18 0 0 0 4 4 19 19 0 0 0 1 18a18 18 0 0 0 5.4 2.7l.6-1a12 12 0 0 1-1.9-.9l.4-.3a13 13 0 0 0 11 0l.4.3a12 12 0 0 1-1.9.9l.6 1A18 18 0 0 0 23 18 19 19 0 0 0 20 4ZM9 15a1.7 1.7 0 0 1 0-3.4A1.7 1.7 0 0 1 9 15Zm6 0a1.7 1.7 0 0 1 0-3.4A1.7 1.7 0 0 1 15 15Z"/></svg>
+        Join
+      </a>
+    </div>
+  </div>
+</nav>
+
+<!-- HERO -->
+<header class="hero" id="top">
+  <div class="court-lines"></div>
+  <div class="ghost-ball"></div>
+  <div class="wrap hero-inner">
+    <div class="eyebrow reveal d1"><span class="dot"></span>Player-run tennis community</div>
+    <h1 class="reveal d2">Need one <em>more?</em></h1>
+    <p class="lede reveal d3">Find people at your level, start your own games, and let the bot handle the planning. Free. Private. Self-hosted — your data stays yours.</p>
+    <div class="cta-row reveal d4">
+      <a class="btn btn-pri btn-lg" href="https://discord.gg/XT3W9hThm">
+        <svg viewBox="0 0 24 24"><path d="M20 4a18 18 0 0 0-4.4-1.4l-.3.6A16 16 0 0 1 17 4a16 16 0 0 0-10 0c.5-.3 1.1-.6 1.7-.8l-.3-.6A18 18 0 0 0 4 4 19 19 0 0 0 1 18a18 18 0 0 0 5.4 2.7l.6-1a12 12 0 0 1-1.9-.9l.4-.3a13 13 0 0 0 11 0l.4.3a12 12 0 0 1-1.9.9l.6 1A18 18 0 0 0 23 18 19 19 0 0 0 20 4ZM9 15a1.7 1.7 0 0 1 0-3.4A1.7 1.7 0 0 1 9 15Zm6 0a1.7 1.7 0 0 1 0-3.4A1.7 1.7 0 0 1 15 15Z"/></svg>
+        Join on Discord
+      </a>
+      <a class="btn btn-ghost btn-lg" href="#how">See how it works</a>
+    </div>
+    <div class="trust reveal d5">
+      <span><svg viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg>No fees, ever</span>
+      <span><svg viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg>No club, no venue</span>
+      <span><svg viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg>Self-hosted &amp; private</span>
+    </div>
+  </div>
+</header>
+
+<!-- PILLARS -->
+<section class="divider" id="how">
+  <div class="wrap">
+    <div class="sec-tag">What you can do</div>
+    <h2 class="sec-title">Three things, no friction.</h2>
+    <div class="pillars">
+      <div class="pcard">
+        <div class="picon"><svg viewBox="0 0 24 24"><circle cx="10.5" cy="10.5" r="6.5"/><line x1="15.5" y1="15.5" x2="21" y2="21"/></svg></div>
+        <h3>Find your players</h3>
+        <p>Matched to your level, your area, and when you actually play. Post that you're free and get a hit.</p>
+      </div>
+      <div class="pcard">
+        <div class="picon"><svg viewBox="0 0 24 24"><circle cx="9" cy="8" r="3"/><circle cx="17" cy="9.5" r="2.4"/><path d="M3.5 19c0-3 2.5-5 5.5-5s5.5 2 5.5 5"/><path d="M15 14.2c2.4.2 4.5 2 4.5 4.8"/></svg></div>
+        <h3>Start your own groups</h3>
+        <p>Spin up a regular game, a ladder, or a private crew for your people. It's yours to run.</p>
+      </div>
+      <div class="pcard">
+        <div class="picon"><svg viewBox="0 0 24 24"><rect x="5" y="8" width="14" height="11" rx="3"/><line x1="12" y1="4" x2="12" y2="8"/><circle cx="12" cy="3.5" r="1.2"/><circle cx="9.5" cy="13" r="1"/><circle cx="14.5" cy="13" r="1"/></svg></div>
+        <h3>The bot plans it</h3>
+        <p>Scheduling, reminders, finding a fourth, court info — all offloaded so you just show up.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- BOT IN ACTION -->
+<section class="divider">
+  <div class="wrap">
+    <div class="bot-grid">
+      <div>
+        <div class="sec-tag">The bot does the legwork</div>
+        <h2 class="sec-title">Stop herding cats in a group chat.</h2>
+        <ul class="bot-points">
+          <li><span class="tick"><svg viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg></span><div><b>Finds a fourth</b><span>Posts the open spot, first to react claims it.</span></div></li>
+          <li><span class="tick"><svg viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg></span><div><b>Runs recurring games</b><span>Same court, same crew, every week — auto-organized.</span></div></li>
+          <li><span class="tick"><svg viewBox="0 0 24 24"><path d="M20 6 9 17l-5-5"/></svg></span><div><b>Nudges &amp; reminders</b><span>Confirmations the day before so nobody flakes.</span></div></li>
+        </ul>
+      </div>
+      <div class="discord-mock">
+        <div class="dm-row">
+          <div class="dm-av">
+            <svg width="26" height="26" viewBox="0 0 120 120" aria-hidden="true">
+              <g transform="translate(60,60) scale(1.2) translate(-76.25,-60)">
+                <path class="arc" d="M46 33 A47 47 0 0 0 46 87" stroke-width="6"/>
+                <path class="arc" d="M55 41 A35 35 0 0 0 55 79" stroke-width="5.2" opacity="0.82"/>
+                <circle cx="90" cy="60" r="25" fill="#79873a"/>
+              </g>
+            </svg>
+          </div>
+          <div>
+            <div class="dm-head"><span class="dm-name">Court Call</span><span class="dm-bot">BOT</span><span class="dm-time">Today at 6:02 PM</span></div>
+            <div class="dm-body">🎾 Marco needs <b>1 more</b> for doubles tomorrow.</div>
+            <div class="dm-embed">
+              <div class="t">Doubles · Riverside Courts</div>
+              <div class="m">Tomorrow · 6:00–7:30 PM · 3.5 level · 3/4 in</div>
+              <div class="dm-react">✅ React to claim the last spot</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- WHAT IT IS / ISN'T -->
+<section class="divider" id="not">
+  <div class="wrap">
+    <div class="sec-tag">Let's be clear</div>
+    <h2 class="sec-title">It's players, not an institution.</h2>
+    <p class="sec-sub">Court Call is a community run by players, for players. Here's what it isn't.</p>
+    <div class="nots">
+      <div class="ncard"><div class="x">A club</div><div class="y">Just players</div><p>No board, no membership tiers, no committee. Peer to peer.</p></div>
+      <div class="ncard"><div class="x">A paid service</div><div class="y">Free to join</div><p>No fees, no upsell. It costs nothing to find a game.</p></div>
+      <div class="ncard"><div class="x">Run by a venue</div><div class="y">Independent</div><p>Not tied to any court or facility. Play wherever you like.</p></div>
+    </div>
+  </div>
+</section>
+
+<!-- PRIVACY -->
+<section class="divider" id="privacy">
+  <div class="wrap">
+    <div class="privacy">
+      <div class="lock"><svg viewBox="0 0 24 24"><rect x="4.5" y="10.5" width="15" height="10" rx="2.5"/><path d="M8 10.5V7a4 4 0 0 1 8 0v3.5"/><circle cx="12" cy="15.5" r="1.4"/></svg></div>
+      <div class="ptext">
+        <h3>Self-hosted. Your data stays yours.</h3>
+        <p>Court Call runs on our own infrastructure — not a third-party platform monetizing your activity. No data selling, no ad tracking. You're here to find a game, not to be the product.</p>
+        <p style="margin-top:14px"><a href="/court-call/privacy/" class="accent" style="font-weight:600">Read the full privacy notice →</a></p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- JOIN -->
+<section class="join divider">
+  <div class="court-lines"></div>
+  <div class="wrap join-inner">
+    <h2>Need one <em>more?</em></h2>
+    <p>Scan or tap to join the Discord. It's free, and someone's always looking for a game.</p>
+    <div class="join-card">
+      <div class="qr-tile"><canvas id="qr"></canvas></div>
+      <div class="jc-text">
+        <div class="h">Join the community</div>
+        <div class="s">Free · Player-run · Private</div>
+        <a class="btn btn-pri" href="https://discord.gg/XT3W9hThm">
+          <svg viewBox="0 0 24 24"><path d="M20 4a18 18 0 0 0-4.4-1.4l-.3.6A16 16 0 0 1 17 4a16 16 0 0 0-10 0c.5-.3 1.1-.6 1.7-.8l-.3-.6A18 18 0 0 0 4 4 19 19 0 0 0 1 18a18 18 0 0 0 5.4 2.7l.6-1a12 12 0 0 1-1.9-.9l.4-.3a13 13 0 0 0 11 0l.4.3a12 12 0 0 1-1.9.9l.6 1A18 18 0 0 0 23 18 19 19 0 0 0 20 4ZM9 15a1.7 1.7 0 0 1 0-3.4A1.7 1.7 0 0 1 9 15Zm6 0a1.7 1.7 0 0 1 0-3.4A1.7 1.7 0 0 1 15 15Z"/></svg>
+          Open Discord
+        </a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="wrap">
+    <span class="brand" style="font-family:var(--disp); font-weight:800; display:inline-flex; align-items:center; gap:9px;">
+      <svg width="22" height="22" viewBox="0 0 120 120" aria-hidden="true"><g transform="translate(60,60) scale(1.2) translate(-76.25,-60)"><path class="arc" d="M46 33 A47 47 0 0 0 46 87" stroke-width="6"/><path class="arc" d="M55 41 A35 35 0 0 0 55 79" stroke-width="5.2" opacity="0.82"/><circle cx="90" cy="60" r="25" fill="#79873a"/></g></svg>
+      Court Call
+    </span>
+    <span class="foot-links" style="display:flex; gap:22px">
+      <a href="/court-call/privacy/" style="color:var(--text)">Privacy</a>
+      <a href="/court-call/community-guidelines/" style="color:var(--text)">Community Guidelines</a>
+    </span>
+    <span>Player-run · Self-hosted · © 2026</span>
+  </div>
+</footer>
+
+<script src="https://cdnjs.cloudflare.com/ajax/libs/qrious/4.0.2/qrious.min.js"></script>
+<script>
+  try{ new QRious({element:document.getElementById('qr'), value:'https://discord.gg/XT3W9hThm',
+    size:240, level:'M', background:'#ffffff', foreground:'#0d1014'}); }catch(e){}
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What

Stands up the **Court Call** tennis-community web hub at `web.aaas24.io/court-call/` — the considered-action destination the printed clinic card's back QR points to (strategy doc names this the canonical hub URL).

## Pages
- **`court-call/index.html`** — landing, verbatim from the approved design (Night Match palette, Bricolage/Familjen, inline logo, QR). Wired to the shared **GTM-5MM9LPM8** container; added footer + privacy-section links to the doc pages. Served as a Jekyll passthrough (no front matter).
- **`_layouts/court-call.html` + `assets/court-call/court-call.css`** — shared dark doc layout (nav/footer, prose styling, `rel=canonical`), independent of the legacy Bootstrap `default.html`.
- **`court-call/docs/{privacy,community-guidelines}.md`** — generated from the canonical sources in `dreams_labs/tennis_community/docs/` (clean permalinks `/court-call/privacy/`, `/court-call/community-guidelines/`).

## Sync model
Docs are **source-driven**: canonical `.md` lives in `dreams_labs/tennis_community`; a pre-push hook there regenerates + commits these pages here. See the companion PR in `dreams_labs`.

## Verified
- Landing + both docs render in the Court Call style at desktop and mobile (Playwright).
- Card back QR already decodes to `https://web.aaas24.io/court-call/` → **no card change needed**.

## Notes
- Hub reuses the existing site GTM container, which is currently **not firing** — tracked in Plane **WEB-7** (fix/standardize site analytics to GA4).
- Commits are **unsigned**: the 1Password SSH signer couldn't sign in the non-interactive shell. Re-sign on merge if desired.
- Goes live on merge to `master` (GitHub Pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)